### PR TITLE
feat: b2c/b2b 스키마 변경

### DIFF
--- a/database/migrations/b2b/001_base_schema.sql
+++ b/database/migrations/b2b/001_base_schema.sql
@@ -1,0 +1,95 @@
+-- =============================================
+-- MovieSir B2B 스키마 생성
+-- 000: 기본 테이블 및 인덱스
+-- 생성일: 2025-01-14
+-- =============================================
+
+BEGIN;
+
+-- B2B 스키마 생성
+CREATE SCHEMA IF NOT EXISTS b2b;
+
+-- =============================================
+-- 1. companies (기업 고객)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.companies (
+    company_id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    manager_email VARCHAR(100) UNIQUE,
+    password_hash VARCHAR(255),
+    plan_type VARCHAR(20) DEFAULT 'BASIC',  -- BASIC, PRO, ENTERPRISE
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- =============================================
+-- 2. api_keys (API 키 관리)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.api_keys (
+    key_id SERIAL PRIMARY KEY,
+    company_id INTEGER REFERENCES b2b.companies(company_id) ON DELETE CASCADE,
+    access_key VARCHAR(64) UNIQUE NOT NULL,
+    key_name VARCHAR(50),
+    daily_limit INTEGER DEFAULT 1000,
+    is_active BOOLEAN DEFAULT TRUE,
+    last_used_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_company_id ON b2b.api_keys(company_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_access_key ON b2b.api_keys(access_key);
+
+-- =============================================
+-- 3. api_usage (일별 사용량 집계)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.api_usage (
+    usage_id BIGSERIAL PRIMARY KEY,
+    key_id INTEGER REFERENCES b2b.api_keys(key_id) ON DELETE CASCADE,
+    usage_date DATE DEFAULT CURRENT_DATE,
+    request_count INTEGER DEFAULT 0,
+    error_count INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_usage_key_date ON b2b.api_usage(key_id, usage_date);
+
+-- =============================================
+-- 4. api_logs (API 원천 로그)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.api_logs (
+    log_id BIGSERIAL PRIMARY KEY,
+    key_id INTEGER REFERENCES b2b.api_keys(key_id) ON DELETE CASCADE,
+    endpoint VARCHAR(100),
+    status_code INTEGER,
+    process_time_ms INTEGER,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_logs_key_id ON b2b.api_logs(key_id);
+CREATE INDEX IF NOT EXISTS idx_api_logs_created_at ON b2b.api_logs(created_at);
+
+-- =============================================
+-- 5. content_rules (브랜드 안전성 규칙)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.content_rules (
+    rule_id SERIAL PRIMARY KEY,
+    company_id INTEGER REFERENCES b2b.companies(company_id) ON DELETE CASCADE,
+    filter_type VARCHAR(20),  -- KEYWORD, GENRE, ID
+    filter_value VARCHAR(100),
+    description TEXT
+);
+
+-- =============================================
+-- 6. guest_sessions (게스트 세션)
+-- =============================================
+CREATE TABLE IF NOT EXISTS b2b.guest_sessions (
+    session_id VARCHAR(36) PRIMARY KEY,
+    key_id INTEGER REFERENCES b2b.api_keys(key_id) ON DELETE CASCADE,
+    flight_time_minutes INTEGER,
+    req_otts VARCHAR(200),
+    created_at TIMESTAMP DEFAULT NOW(),
+    expires_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_guest_sessions_key_id ON b2b.guest_sessions(key_id);
+
+COMMIT;

--- a/database/migrations/b2b/002_add_oauth_provider.sql
+++ b/database/migrations/b2b/002_add_oauth_provider.sql
@@ -1,0 +1,16 @@
+-- =============================================
+-- MovieSir B2B 마이그레이션
+-- 001: OAuth provider 컬럼 추가
+-- 생성일: 2025-01-14
+-- =============================================
+
+BEGIN;
+
+-- companies 테이블에 oauth_provider 컬럼 추가
+-- google, github 등 소셜 로그인 제공자 저장
+ALTER TABLE b2b.companies
+ADD COLUMN IF NOT EXISTS oauth_provider VARCHAR(20);
+
+COMMENT ON COLUMN b2b.companies.oauth_provider IS '소셜 로그인 제공자 (google, github)';
+
+COMMIT;

--- a/database/migrations/b2c/003_move_to_b2c_schema.sql
+++ b/database/migrations/b2c/003_move_to_b2c_schema.sql
@@ -1,0 +1,52 @@
+-- =============================================
+-- MovieSir B2C 스키마 분리
+-- 003: public → b2c 스키마 이동
+-- 생성일: 2025-01-14
+--
+-- 주의: 이 마이그레이션은 이미 실행됨 (기록용)
+-- =============================================
+
+BEGIN;
+
+-- B2C 스키마 생성
+CREATE SCHEMA IF NOT EXISTS b2c;
+
+-- =============================================
+-- public → b2c 스키마로 테이블 이동 (8개)
+-- =============================================
+
+-- 1. users
+ALTER TABLE public.users SET SCHEMA b2c;
+
+-- 2. user_vectors
+ALTER TABLE public.user_vectors SET SCHEMA b2c;
+
+-- 3. user_ott_map
+ALTER TABLE public.user_ott_map SET SCHEMA b2c;
+
+-- 4. user_onboarding_answers
+ALTER TABLE public.user_onboarding_answers SET SCHEMA b2c;
+
+-- 5. user_movie_feedback
+ALTER TABLE public.user_movie_feedback SET SCHEMA b2c;
+
+-- 6. movie_logs
+ALTER TABLE public.movie_logs SET SCHEMA b2c;
+
+-- 7. recommendation_sessions
+ALTER TABLE public.recommendation_sessions SET SCHEMA b2c;
+
+-- 8. onboarding_candidates
+ALTER TABLE public.onboarding_candidates SET SCHEMA b2c;
+
+-- =============================================
+-- public에 유지되는 테이블 (4개) - 공통 데이터
+-- =============================================
+-- movies, movie_vectors, movie_ott_map, ott_providers
+
+-- =============================================
+-- search_path 설정 (중요!)
+-- =============================================
+ALTER ROLE movigation SET search_path TO public, b2c, b2b;
+
+COMMIT;


### PR DESCRIPTION
## 작업 내용

### B2B 스키마 초기화 (`001_base_schema.sql`)
- `b2b` 스키마 생성
- `companies` 테이블: 기업 고객 정보 (name, manager_email, password_hash, plan_type, oauth_provider)
- `api_keys` 테이블: API 키 관리 (access_key, key_name, daily_limit)
- `api_usage` 테이블: 일별 사용량 집계
- `api_logs` 테이블: API 호출 로그
- `content_rules` 테이블: 브랜드 안전성 규칙
- `guest_sessions` 테이블: 게스트 추천 세션
- 성능 인덱스 7개 추가

### OAuth 지원 (`002_add_oauth_provider.sql`)
- `companies.oauth_provider` 컬럼 추가 (google, github 소셜 로그인)

### B2C 스키마 분리 (`003_move_to_b2c_schema.sql`)
- 기존 public 스키마 테이블 → b2c 스키마로 이동
- users, user_vectors, user_ott_map 등 8개 테이블
