### PR TITLE
[AI]: Production 추천 시스템 성능 평가 노트북 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ ai/compare/cbf/inner_results/*
 ai/compare/cbf/outer_results/*
 !ai/compare/cbf/outer_results/.gitkeep
 
+# production
+ai/compare/production/production_evaluation_results.json
 
 # DB
 *.sql

--- a/ai/compare/production/real_final_compare.ipynb
+++ b/ai/compare/production/real_final_compare.ipynb
@@ -1,0 +1,752 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Production 추천 시스템 성능 평가\n",
+    "\n",
+    "**목표**: 실제 프로덕션 코드와 동일한 로직으로 성능 평가\n",
+    "\n",
+    "**평가 지표**:\n",
+    "- Precision@10: 상위 10개 추천 중 정답 비율\n",
+    "- Recall@10: 테스트 영화 중 추천된 비율\n",
+    "- NDCG@10: 순위를 고려한 정확도\n",
+    "- 추천 소요 시간"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1단계: 환경 설정"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "환경 설정 완료\n",
+      "  프로젝트 루트: /Users/apple/kakao2-project/MovieSir\n",
+      "  AI 폴더: /Users/apple/kakao2-project/MovieSir/ai\n",
+      "  시드: 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from typing import List, Dict, Tuple, Any\n",
+    "from dotenv import load_dotenv\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from math import log\n",
+    "\n",
+    "# 시드 고정\n",
+    "SEED = 42\n",
+    "random.seed(SEED)\n",
+    "np.random.seed(SEED)\n",
+    "\n",
+    "# 프로젝트 경로 설정\n",
+    "project_root = Path().absolute().parent.parent.parent\n",
+    "ai_root = project_root / 'ai'\n",
+    "sys.path.insert(0, str(ai_root))\n",
+    "\n",
+    "# 환경 변수 로드\n",
+    "env_file = project_root / '.env.local'\n",
+    "if not env_file.exists():\n",
+    "    env_file = project_root / '.env'\n",
+    "load_dotenv(env_file)\n",
+    "\n",
+    "print(f'환경 설정 완료')\n",
+    "print(f'  프로젝트 루트: {project_root}')\n",
+    "print(f'  AI 폴더: {ai_root}')\n",
+    "print(f'  시드: {SEED}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2단계: 추천 시스템 초기화"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "추천 시스템 초기화 중...\n",
+      "Initializing Hybrid Recommender (SBERT + ALS, Noise-based Diversity)...\n",
+      "Loading metadata from database...\n",
+      "  Metadata loaded: 13,060 movies\n",
+      "Loading SBERT embeddings from database...\n",
+      "  SBERT movies: 13,060\n",
+      "Loading OTT data from database...\n",
+      "  OTT data loaded: 13,047 movies\n",
+      "  ALS movies: 11,659\n",
+      "Loading ALS model from /Users/apple/kakao2-project/MovieSir/ai/training/als_data\n",
+      "  ALS item factors shape: (65032, 128)\n",
+      "Pre-aligning models...\n",
+      "Created reverse mapping dictionary for 13,060 movies\n",
+      "  ⚠️  1401 movies have SBERT only (will use SBERT weight 1.0)\n",
+      "Pre-calculating rating scores...\n",
+      "Pre-calculated rating scores for 13,060 movies\n",
+      "Building filtering indexes...\n",
+      "  Year index: 105 years\n",
+      "  Genre index: 20 genres\n",
+      "  OTT index: 9 providers\n",
+      "Initialization complete. Target movies: 13060\n",
+      "\n",
+      "초기화 완료\n",
+      "  전체 영화 수: 13,060개\n",
+      "  SBERT 임베딩: 13,060개\n",
+      "  ALS 임베딩: 11,659개\n"
+     ]
+    }
+   ],
+   "source": [
+    "from inference.recommendation_model import HybridRecommender\n",
+    "\n",
+    "# DB 설정\n",
+    "DB_CONFIG = {\n",
+    "    'host': os.getenv('DATABASE_HOST', 'localhost'),\n",
+    "    'port': int(os.getenv('DATABASE_PORT', 5432)),\n",
+    "    'database': os.getenv('DATABASE_NAME', 'moviesir'),\n",
+    "    'user': os.getenv('DATABASE_USER', 'movigation'),\n",
+    "    'password': os.getenv('DATABASE_PASSWORD', 'moviesir123')\n",
+    "}\n",
+    "\n",
+    "# 모델 경로\n",
+    "ALS_MODEL_PATH = str(ai_root / 'training/als_data')\n",
+    "ALS_DATA_PATH = str(ai_root / 'training/als_data')\n",
+    "\n",
+    "print('추천 시스템 초기화 중...')\n",
+    "recommender = HybridRecommender(\n",
+    "    db_config=DB_CONFIG,\n",
+    "    als_model_path=ALS_MODEL_PATH,\n",
+    "    als_data_path=ALS_DATA_PATH\n",
+    ")\n",
+    "print(f'\\n초기화 완료')\n",
+    "print(f'  전체 영화 수: {len(recommender.metadata_map):,}개')\n",
+    "print(f'  SBERT 임베딩: {len(recommender.sbert_movie_to_idx):,}개')\n",
+    "print(f'  ALS 임베딩: {len(recommender.als_movie_to_idx):,}개')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3단계: 테스트 사용자 데이터 로드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ratings.csv 로드 중...\n",
+      "  파일: /Users/apple/kakao2-project/MovieSir/ai/training/original_data/ratings.csv\n",
+      "\n",
+      "로드 완료\n",
+      "  전체 평점 수: 32,000,204개\n",
+      "  전체 사용자: 200,948명\n",
+      "  전체 영화: 84,432개\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ratings.csv 경로\n",
+    "RATINGS_CSV_PATH = ai_root / 'training/original_data/ratings.csv'\n",
+    "\n",
+    "print(f'ratings.csv 로드 중...')\n",
+    "print(f'  파일: {RATINGS_CSV_PATH}')\n",
+    "\n",
+    "df_ratings = pd.read_csv(RATINGS_CSV_PATH)\n",
+    "print(f'\\n로드 완료')\n",
+    "print(f'  전체 평점 수: {len(df_ratings):,}개')\n",
+    "print(f'  전체 사용자: {df_ratings[\"userId\"].nunique():,}명')\n",
+    "print(f'  전체 영화: {df_ratings[\"movieId\"].nunique():,}개')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DB 존재 영화 필터링:\n",
+      "  필터링 전: 32,000,204개\n",
+      "  필터링 후: 23,129,818개 (72.3%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# DB에 존재하는 영화만 필터링\n",
+    "valid_movie_ids = set(recommender.metadata_map.keys())\n",
+    "df_valid = df_ratings[df_ratings['movieId'].isin(valid_movie_ids)].copy()\n",
+    "\n",
+    "print(f'DB 존재 영화 필터링:')\n",
+    "print(f'  필터링 전: {len(df_ratings):,}개')\n",
+    "print(f'  필터링 후: {len(df_valid):,}개 ({len(df_valid)/len(df_ratings)*100:.1f}%)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2000년 이후 + 비성인물 필터링:\n",
+      "  필터링 후 평점: 8,518,542개\n",
+      "  필터링 후 영화: 7,951개\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2000년 이후, 비성인물만 필터링 (프로덕션과 동일)\n",
+    "valid_filtered_ids = set()\n",
+    "\n",
+    "for mid in df_valid['movieId'].unique():\n",
+    "    meta = recommender.metadata_map.get(mid, {})\n",
+    "    \n",
+    "    # 2000년 이상 체크\n",
+    "    release_date = meta.get('release_date', '')\n",
+    "    if release_date:\n",
+    "        try:\n",
+    "            year = int(release_date[:4])\n",
+    "            if year < 2000:\n",
+    "                continue\n",
+    "        except:\n",
+    "            continue\n",
+    "    \n",
+    "    # 비성인물 체크\n",
+    "    if meta.get('adult', False):\n",
+    "        continue\n",
+    "    \n",
+    "    valid_filtered_ids.add(mid)\n",
+    "\n",
+    "df_filtered = df_valid[df_valid['movieId'].isin(valid_filtered_ids)].copy()\n",
+    "\n",
+    "print(f'2000년 이후 + 비성인물 필터링:')\n",
+    "print(f'  필터링 후 평점: {len(df_filtered):,}개')\n",
+    "print(f'  필터링 후 영화: {df_filtered[\"movieId\"].nunique():,}개')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20개 이상 평가한 사용자: 85,033명\n",
+      "\n",
+      "100명의 테스트 사용자 추출 완료\n",
+      "  평균 train 영화 수: 1045.8개\n",
+      "  평균 test 영화 수: 261.9개\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 테스트 사용자 추출\n",
+    "MIN_RATINGS = 20  # 최소 평가 수\n",
+    "NUM_USERS = 100   # 최대 사용자 수\n",
+    "\n",
+    "user_counts = df_filtered.groupby('userId').size()\n",
+    "valid_users = user_counts[user_counts >= MIN_RATINGS].index.tolist()\n",
+    "print(f'{MIN_RATINGS}개 이상 평가한 사용자: {len(valid_users):,}명')\n",
+    "\n",
+    "# 상위 NUM_USERS 명 선택\n",
+    "top_users = user_counts.nlargest(NUM_USERS).index.tolist()\n",
+    "\n",
+    "test_users = []\n",
+    "for user_id in top_users:\n",
+    "    user_ratings = df_filtered[df_filtered['userId'] == user_id].sort_values('timestamp')\n",
+    "    movies = user_ratings['movieId'].tolist()\n",
+    "    \n",
+    "    # 80% train, 20% test 분할\n",
+    "    split_idx = int(len(movies) * 0.8)\n",
+    "    train = movies[:split_idx]\n",
+    "    test = movies[split_idx:]\n",
+    "    \n",
+    "    if len(train) >= 15 and len(test) >= 5:\n",
+    "        test_users.append((user_id, train, test))\n",
+    "\n",
+    "print(f'\\n{len(test_users)}명의 테스트 사용자 추출 완료')\n",
+    "avg_train = sum(len(t) for _, t, _ in test_users) / len(test_users)\n",
+    "avg_test = sum(len(t) for _, _, t in test_users) / len(test_users)\n",
+    "print(f'  평균 train 영화 수: {avg_train:.1f}개')\n",
+    "print(f'  평균 test 영화 수: {avg_test:.1f}개')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4단계: 평가 함수 정의 (프로덕션과 동일한 로직)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "평가 함수 정의 완료 (프로덕션 로직 반영)\n",
+      "  - ALS: 정규화 없음 (일반 내적)\n",
+      "  - 평점 점수: 30% 반영\n"
+     ]
+    }
+   ],
+   "source": [
+    "def get_top_movies_production(\n",
+    "    recommender,\n",
+    "    user_sbert_profile: np.ndarray,\n",
+    "    user_als_profile: np.ndarray,\n",
+    "    candidate_ids: List[int],\n",
+    "    sbert_weight: float,\n",
+    "    als_weight: float,\n",
+    "    top_k: int = 10\n",
+    ") -> List[Dict[str, Any]]:\n",
+    "    \"\"\"\n",
+    "    프로덕션과 동일한 로직으로 상위 영화 선정\n",
+    "    \n",
+    "    수정 사항 (fianl_compare.py 대비):\n",
+    "    1. ALS 정규화 제거 (프로덕션은 정규화 안 함)\n",
+    "    2. 평점 점수 30% 반영 추가\n",
+    "    \"\"\"\n",
+    "    candidate_indices = []\n",
+    "    for mid in candidate_ids:\n",
+    "        idx = recommender.movie_id_to_idx.get(mid)\n",
+    "        if idx is not None:\n",
+    "            candidate_indices.append((mid, idx))\n",
+    "    \n",
+    "    if not candidate_indices:\n",
+    "        return []\n",
+    "    \n",
+    "    indices = [idx for _, idx in candidate_indices]\n",
+    "    \n",
+    "    # SBERT: 정규화된 벡터 (코사인 유사도)\n",
+    "    sbert_similarities = recommender.target_sbert_norm[indices] @ user_sbert_profile.T\n",
+    "    \n",
+    "    # ALS: 정규화 안 함 (일반 내적) - 프로덕션과 동일!\n",
+    "    als_similarities = recommender.target_als_matrix[indices] @ user_als_profile.T\n",
+    "    \n",
+    "    sbert_scores = np.max(sbert_similarities, axis=1)\n",
+    "    als_scores = np.max(als_similarities, axis=1)\n",
+    "    \n",
+    "    scaler = MinMaxScaler()\n",
+    "    filtered_rating = np.array([recommender.rating_scores.get(mid, 0.0) for mid, _ in candidate_indices])\n",
+    "    \n",
+    "    if len(sbert_scores) > 1:\n",
+    "        norm_sbert = scaler.fit_transform(sbert_scores.reshape(-1, 1)).squeeze()\n",
+    "        norm_als = scaler.fit_transform(als_scores.reshape(-1, 1)).squeeze()\n",
+    "        norm_rating = scaler.fit_transform(filtered_rating.reshape(-1, 1)).squeeze()\n",
+    "    else:\n",
+    "        norm_sbert = sbert_scores\n",
+    "        norm_als = als_scores\n",
+    "        norm_rating = filtered_rating\n",
+    "    \n",
+    "    als_ids = set(recommender.als_movie_to_idx.keys())\n",
+    "    \n",
+    "    movie_scores = []\n",
+    "    for i, (mid, _) in enumerate(candidate_indices):\n",
+    "        if mid in als_ids:\n",
+    "            model_score = sbert_weight * norm_sbert[i] + als_weight * norm_als[i]\n",
+    "        else:\n",
+    "            model_score = norm_sbert[i]\n",
+    "        \n",
+    "        rating_score = norm_rating[i] if isinstance(norm_rating, np.ndarray) else norm_rating\n",
+    "        final_score = model_score * 0.7 + rating_score * 0.3\n",
+    "        \n",
+    "        meta = recommender.metadata_map.get(mid, {})\n",
+    "        movie_scores.append({\n",
+    "            'movie_id': mid,\n",
+    "            'title': meta.get('title', 'Unknown'),\n",
+    "            'genres': meta.get('genres', []),\n",
+    "            'score': final_score\n",
+    "        })\n",
+    "    \n",
+    "    movie_scores.sort(key=lambda x: x['score'], reverse=True)\n",
+    "    return movie_scores[:top_k]\n",
+    "\n",
+    "print('평가 함수 정의 완료 (프로덕션 로직 반영)')\n",
+    "print('  - ALS: 정규화 없음 (일반 내적)')\n",
+    "print('  - 평점 점수: 30% 반영')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "평가 지표 함수 정의 완료\n"
+     ]
+    }
+   ],
+   "source": [
+    "def calculate_precision_at_k(recommendations, ground_truth, k=10):\n",
+    "    top_k = recommendations[:k]\n",
+    "    relevant = set(ground_truth)\n",
+    "    hits = len(set(top_k) & relevant)\n",
+    "    return hits / k if k > 0 else 0.0\n",
+    "\n",
+    "def calculate_recall_at_k(recommendations, ground_truth, k=10):\n",
+    "    top_k = recommendations[:k]\n",
+    "    relevant = set(ground_truth)\n",
+    "    hits = len(set(top_k) & relevant)\n",
+    "    return hits / len(relevant) if len(relevant) > 0 else 0.0\n",
+    "\n",
+    "def calculate_ndcg_at_k(recommendations, ground_truth, k=10):\n",
+    "    top_k = recommendations[:k]\n",
+    "    relevant = set(ground_truth)\n",
+    "    relevance = np.array([1.0 if mid in relevant else 0.0 for mid in top_k])\n",
+    "    \n",
+    "    if relevance.sum() == 0:\n",
+    "        return 0.0\n",
+    "    \n",
+    "    dcg = sum(rel / np.log2(i + 2) for i, rel in enumerate(relevance))\n",
+    "    ideal_relevance = np.sort(relevance)[::-1]\n",
+    "    idcg = sum(rel / np.log2(i + 2) for i, rel in enumerate(ideal_relevance))\n",
+    "    \n",
+    "    return dcg / idcg if idcg > 0 else 0.0\n",
+    "\n",
+    "print('평가 지표 함수 정의 완료')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5단계: 평가 실행"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Production 추천 시스템 평가 시작\n",
+      "  - K: 10\n",
+      "  - SBERT 가중치: 0.7\n",
+      "  - ALS 가중치: 0.3\n",
+      "  - 테스트 사용자: 100명\n",
+      "============================================================\n",
+      "  진행: 20/100 users\n",
+      "  진행: 40/100 users\n",
+      "  진행: 60/100 users\n",
+      "  진행: 80/100 users\n",
+      "  진행: 100/100 users\n",
+      "\n",
+      "평가 완료: 100명\n"
+     ]
+    }
+   ],
+   "source": [
+    "K = 10\n",
+    "SBERT_WEIGHT = 0.7\n",
+    "ALS_WEIGHT = 0.3\n",
+    "\n",
+    "precision_scores = []\n",
+    "recall_scores = []\n",
+    "ndcg_scores = []\n",
+    "elapsed_times = []\n",
+    "\n",
+    "print('='*60)\n",
+    "print('Production 추천 시스템 평가 시작')\n",
+    "print(f'  - K: {K}')\n",
+    "print(f'  - SBERT 가중치: {SBERT_WEIGHT}')\n",
+    "print(f'  - ALS 가중치: {ALS_WEIGHT}')\n",
+    "print(f'  - 테스트 사용자: {len(test_users)}명')\n",
+    "print('='*60)\n",
+    "\n",
+    "for idx, (user_id, train_movies, test_movies) in enumerate(test_users):\n",
+    "    start_time = time.time()\n",
+    "    \n",
+    "    try:\n",
+    "        user_sbert_profile, user_als_profile = recommender._get_user_profile(train_movies)\n",
+    "        all_movie_ids = list(recommender.metadata_map.keys())\n",
+    "        candidate_ids = [mid for mid in all_movie_ids if mid not in train_movies]\n",
+    "        \n",
+    "        top_movies = get_top_movies_production(\n",
+    "            recommender=recommender,\n",
+    "            user_sbert_profile=user_sbert_profile,\n",
+    "            user_als_profile=user_als_profile,\n",
+    "            candidate_ids=candidate_ids,\n",
+    "            sbert_weight=SBERT_WEIGHT,\n",
+    "            als_weight=ALS_WEIGHT,\n",
+    "            top_k=K\n",
+    "        )\n",
+    "        \n",
+    "        elapsed = time.time() - start_time\n",
+    "        elapsed_times.append(elapsed)\n",
+    "        \n",
+    "        top_k_ids = [m['movie_id'] for m in top_movies]\n",
+    "        \n",
+    "        precision_scores.append(calculate_precision_at_k(top_k_ids, test_movies, K))\n",
+    "        recall_scores.append(calculate_recall_at_k(top_k_ids, test_movies, K))\n",
+    "        ndcg_scores.append(calculate_ndcg_at_k(top_k_ids, test_movies, K))\n",
+    "        \n",
+    "        if (idx + 1) % 20 == 0:\n",
+    "            print(f'  진행: {idx + 1}/{len(test_users)} users')\n",
+    "            \n",
+    "    except Exception as e:\n",
+    "        print(f'  User {user_id} 평가 실패: {e}')\n",
+    "        continue\n",
+    "\n",
+    "print(f'\\n평가 완료: {len(precision_scores)}명')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6단계: 결과 분석"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Production 추천 시스템 성능 평가 결과\n",
+      "============================================================\n",
+      "\n",
+      "정확도 지표:\n",
+      "  Precision@10: 0.2110\n",
+      "  Recall@10:    0.0085\n",
+      "  NDCG@10:      0.4657\n",
+      "\n",
+      "속도 지표:\n",
+      "  평균 추천 시간: 0.387s (+/-0.124s)\n",
+      "\n",
+      "평가 규모:\n",
+      "  평가 사용자: 100명\n",
+      "============================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = {\n",
+    "    'Precision@10': np.mean(precision_scores),\n",
+    "    'Recall@10': np.mean(recall_scores),\n",
+    "    'NDCG@10': np.mean(ndcg_scores),\n",
+    "    'avg_time': np.mean(elapsed_times),\n",
+    "    'std_time': np.std(elapsed_times),\n",
+    "    'num_users': len(precision_scores)\n",
+    "}\n",
+    "\n",
+    "print('='*60)\n",
+    "print('Production 추천 시스템 성능 평가 결과')\n",
+    "print('='*60)\n",
+    "print(f'\\n정확도 지표:')\n",
+    "print(f'  Precision@{K}: {results[\"Precision@10\"]:.4f}')\n",
+    "print(f'  Recall@{K}:    {results[\"Recall@10\"]:.4f}')\n",
+    "print(f'  NDCG@{K}:      {results[\"NDCG@10\"]:.4f}')\n",
+    "print(f'\\n속도 지표:')\n",
+    "print(f'  평균 추천 시간: {results[\"avg_time\"]:.3f}s (+/-{results[\"std_time\"]:.3f}s)')\n",
+    "print(f'\\n평가 규모:')\n",
+    "print(f'  평가 사용자: {results[\"num_users\"]}명')\n",
+    "print('='*60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "점수 분포 분석:\n",
+      "\n",
+      "Precision@10:\n",
+      "  Min: 0.0000\n",
+      "  Max: 0.7000\n",
+      "  Median: 0.2000\n",
+      "  Std: 0.1536\n",
+      "\n",
+      "Recall@10:\n",
+      "  Min: 0.0000\n",
+      "  Max: 0.0314\n",
+      "  Median: 0.0081\n",
+      "  Std: 0.0066\n",
+      "\n",
+      "NDCG@10:\n",
+      "  Min: 0.0000\n",
+      "  Max: 0.9060\n",
+      "  Median: 0.4842\n",
+      "  Std: 0.2524\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('점수 분포 분석:')\n",
+    "print(f'\\nPrecision@{K}:')\n",
+    "print(f'  Min: {np.min(precision_scores):.4f}')\n",
+    "print(f'  Max: {np.max(precision_scores):.4f}')\n",
+    "print(f'  Median: {np.median(precision_scores):.4f}')\n",
+    "print(f'  Std: {np.std(precision_scores):.4f}')\n",
+    "\n",
+    "print(f'\\nRecall@{K}:')\n",
+    "print(f'  Min: {np.min(recall_scores):.4f}')\n",
+    "print(f'  Max: {np.max(recall_scores):.4f}')\n",
+    "print(f'  Median: {np.median(recall_scores):.4f}')\n",
+    "print(f'  Std: {np.std(recall_scores):.4f}')\n",
+    "\n",
+    "print(f'\\nNDCG@{K}:')\n",
+    "print(f'  Min: {np.min(ndcg_scores):.4f}')\n",
+    "print(f'  Max: {np.max(ndcg_scores):.4f}')\n",
+    "print(f'  Median: {np.median(ndcg_scores):.4f}')\n",
+    "print(f'  Std: {np.std(ndcg_scores):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "결과 요약 테이블:\n",
+      "          지표      값\n",
+      "Precision@10 0.2110\n",
+      "   Recall@10 0.0085\n",
+      "     NDCG@10 0.4657\n",
+      " 평균 추천 시간(s)  0.387\n"
+     ]
+    }
+   ],
+   "source": [
+    "summary_df = pd.DataFrame({\n",
+    "    '지표': ['Precision@10', 'Recall@10', 'NDCG@10', '평균 추천 시간(s)'],\n",
+    "    '값': [\n",
+    "        f\"{results['Precision@10']:.4f}\",\n",
+    "        f\"{results['Recall@10']:.4f}\",\n",
+    "        f\"{results['NDCG@10']:.4f}\",\n",
+    "        f\"{results['avg_time']:.3f}\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "print('\\n결과 요약 테이블:')\n",
+    "print(summary_df.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7단계: 결과 저장"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "결과 저장 완료: production_evaluation_results.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from datetime import datetime\n",
+    "\n",
+    "output_data = {\n",
+    "    'metadata': {\n",
+    "        'created_at': datetime.now().isoformat(),\n",
+    "        'model': 'Production Hybrid (SBERT 0.7 + ALS 0.3)',\n",
+    "        'k': K,\n",
+    "        'num_users': len(precision_scores),\n",
+    "        'seed': SEED\n",
+    "    },\n",
+    "    'results': {\n",
+    "        'precision@10': float(results['Precision@10']),\n",
+    "        'recall@10': float(results['Recall@10']),\n",
+    "        'ndcg@10': float(results['NDCG@10']),\n",
+    "        'avg_time': float(results['avg_time']),\n",
+    "        'std_time': float(results['std_time'])\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "output_path = Path('production_evaluation_results.json')\n",
+    "with open(output_path, 'w', encoding='utf-8') as f:\n",
+    "    json.dump(output_data, f, ensure_ascii=False, indent=2)\n",
+    "\n",
+    "print(f'결과 저장 완료: {output_path}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## 작업 내용
- 프로덕션 추천 알고리즘과 동일한 로직으로 성능 평가 노트북 추가
- 기존 fianl_compare.py의 오류 수정 (ALS 정규화, 평점 점수 미반영)
- MovieLens 32M 데이터 기반 평가

## 체크리스트
- 로컬 테스트 완료
- 코드 리뷰 요청
